### PR TITLE
Improve MNO data simulator resilience

### DIFF
--- a/database/MIGRATION.md
+++ b/database/MIGRATION.md
@@ -82,6 +82,11 @@ WHERE a.ctid < b.ctid
 
 **2. Add the unique constraint**
 
+Note: TimescaleDB only allows adding a unique constraint when no chunks are
+compressed.  Run this step before the compression policy has had a chance to
+compress any chunks (i.e. shortly after a fresh deploy or after
+decompressing all chunks with `SELECT decompress_chunk(c) FROM show_chunks('cml_data') c`).
+
 ```bash
 docker compose exec database psql -U myuser -d mydatabase -c "
 ALTER TABLE cml_data ADD CONSTRAINT cml_data_unique_obs
@@ -89,5 +94,8 @@ ALTER TABLE cml_data ADD CONSTRAINT cml_data_unique_obs
 "
 ```
 
-Note: TimescaleDB requires that unique indexes on hypertables include the
-partitioning column (`time`), which is satisfied here.
+If compressed chunks already exist (>7 days of data), skip this step — the
+`ON CONFLICT DO NOTHING` in the parser still prevents duplicates at the
+application level.  The constraint is enforced automatically on fresh
+deployments because `init.sql` declares it before any data or compression
+policy is applied.

--- a/database/MIGRATION.md
+++ b/database/MIGRATION.md
@@ -257,24 +257,37 @@ completes the refresh policy keeps the view up to date automatically.
 
 **Branch:** `fix/mno-simulator-resilience`
 
-A `UNIQUE (time, cml_id, sublink_id)` constraint was added to `cml_data` so
-that re-processing the same file never creates duplicate rows.  The parser's
-`write_rawdata` now uses `ON CONFLICT DO NOTHING`.
+A `UNIQUE (time, cml_id, sublink_id, user_id)` constraint was added to
+`cml_data` so that re-processing the same file never creates duplicate rows.
+The parser's `write_rawdata` now uses `ON CONFLICT DO NOTHING`.
 
 ### Steps
 
 **1. Deduplicate existing data (if any duplicates are present)**
 
+> **Note:** `DELETE … USING … WHERE a.ctid < b.ctid` does **not** work on
+> TimescaleDB compressed chunks (the `ctid` comparison is skipped by the
+> planner).  Use the temp-table approach below instead.
+
 ```bash
 docker compose exec database psql -U myuser -d mydatabase -c "
-DELETE FROM cml_data a
-USING cml_data b
-WHERE a.ctid < b.ctid
-  AND a.time        = b.time
-  AND a.cml_id      = b.cml_id
-  AND a.sublink_id  = b.sublink_id;
+-- Identify unique rows to keep
+CREATE TEMP TABLE cml_data_dedup AS
+SELECT DISTINCT ON (time, cml_id, sublink_id, user_id)
+    time, cml_id, sublink_id, rsl, tsl, user_id
+FROM cml_data
+ORDER BY time, cml_id, sublink_id, user_id;
+
+-- Remove all rows in each affected chunk and reinsert the deduped set.
+-- Adjust the chunk name(s) to match your installation
+-- (\`SELECT show_chunks('cml_data')\` lists them).
+DELETE FROM _timescaledb_internal._hyper_1_12_chunk;
+INSERT INTO cml_data SELECT * FROM cml_data_dedup;
+DROP TABLE cml_data_dedup;
 "
 ```
+
+Alternatively restore from a pre-duplicate backup (safest).
 
 **2. Add the unique constraint**
 
@@ -286,7 +299,7 @@ decompressing all chunks with `SELECT decompress_chunk(c) FROM show_chunks('cml_
 ```bash
 docker compose exec database psql -U myuser -d mydatabase -c "
 ALTER TABLE cml_data ADD CONSTRAINT cml_data_unique_obs
-    UNIQUE (time, cml_id, sublink_id);
+    UNIQUE (time, cml_id, sublink_id, user_id);
 "
 ```
 

--- a/database/MIGRATION.md
+++ b/database/MIGRATION.md
@@ -54,3 +54,40 @@ CALL refresh_continuous_aggregate('cml_data_1h', NULL, NULL);
 
 This may take a few seconds depending on how much data is present. After it
 completes the refresh policy keeps the view up to date automatically.
+
+---
+
+## Unique constraint on `cml_data` (idempotent ingestion)
+
+**Branch:** `fix/mno-simulator-resilience`
+
+A `UNIQUE (time, cml_id, sublink_id)` constraint was added to `cml_data` so
+that re-processing the same file never creates duplicate rows.  The parser's
+`write_rawdata` now uses `ON CONFLICT DO NOTHING`.
+
+### Steps
+
+**1. Deduplicate existing data (if any duplicates are present)**
+
+```bash
+docker compose exec database psql -U myuser -d mydatabase -c "
+DELETE FROM cml_data a
+USING cml_data b
+WHERE a.ctid < b.ctid
+  AND a.time        = b.time
+  AND a.cml_id      = b.cml_id
+  AND a.sublink_id  = b.sublink_id;
+"
+```
+
+**2. Add the unique constraint**
+
+```bash
+docker compose exec database psql -U myuser -d mydatabase -c "
+ALTER TABLE cml_data ADD CONSTRAINT cml_data_unique_obs
+    UNIQUE (time, cml_id, sublink_id);
+"
+```
+
+Note: TimescaleDB requires that unique indexes on hypertables include the
+partitioning column (`time`), which is satisfied here.

--- a/database/init.sql
+++ b/database/init.sql
@@ -3,7 +3,8 @@ CREATE TABLE cml_data (
     cml_id TEXT NOT NULL,
     sublink_id TEXT NOT NULL,
     rsl REAL,
-    tsl REAL
+    tsl REAL,
+    UNIQUE (time, cml_id, sublink_id)
 );
 
 CREATE TABLE cml_metadata (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   mno_simulator:
     build: ./mno_data_source_simulator
+    restart: unless-stopped
     depends_on:
       - sftp_receiver
     volumes:

--- a/mno_data_source_simulator/main.py
+++ b/mno_data_source_simulator/main.py
@@ -172,7 +172,12 @@ def main():
                         uploaded_count = sftp_uploader.upload_pending_files()
                         if uploaded_count > 0:
                             logger.info(f"Uploaded {uploaded_count} files")
-                            last_upload_time = current_time
+                        # Always advance the timer so a persistent connection
+                        # failure does not cause every loop iteration to
+                        # attempt uploading the full backlog (which would
+                        # allocate paramiko packet buffers for each file and
+                        # exhaust container RAM).
+                        last_upload_time = current_time
                     except Exception as e:
                         logger.error(f"Upload failed: {e}")
 

--- a/mno_data_source_simulator/sftp_uploader.py
+++ b/mno_data_source_simulator/sftp_uploader.py
@@ -33,6 +33,7 @@ class SFTPUploader:
         source_dir: str = "data_to_upload",
         archive_dir: str = "data_uploaded",
         connection_timeout: int = 30,
+        max_files_per_call: int = 200,
     ):
         """
         Initialize the SFTP uploader.
@@ -70,6 +71,9 @@ class SFTPUploader:
             "~/.ssh/known_hosts"
         )
         self.connection_timeout = connection_timeout
+        # Cap how many files are uploaded in a single call.  This bounds
+        # worst-case paramiko buffer allocation if failures slip through.
+        self.max_files_per_call = max_files_per_call
 
         # Validate remote path
         self.remote_path = self._validate_remote_path(remote_path)
@@ -426,10 +430,27 @@ class SFTPUploader:
             logger.debug("No pending files to upload")
             return 0
 
+        if len(pending_files) > self.max_files_per_call:
+            logger.info(
+                "Capping upload batch to %d of %d pending files",
+                self.max_files_per_call,
+                len(pending_files),
+            )
+            pending_files = pending_files[: self.max_files_per_call]
+
         uploaded_count = 0
         reconnect_attempted = False
 
         for file_path in pending_files:
+            # Per-file transport check: bail out immediately if the socket
+            # has gone away mid-batch instead of letting paramiko allocate
+            # packet buffers for every remaining file before failing.
+            if not self._is_connected():
+                logger.warning("Transport lost mid-batch; attempting reconnect")
+                if reconnect_attempted or not self.reconnect():
+                    logger.error("Could not recover connection; aborting batch")
+                    break
+                reconnect_attempted = True
             try:
                 # Upload the file
                 remote_file_path = self.upload_file(str(file_path))

--- a/mno_data_source_simulator/sftp_uploader.py
+++ b/mno_data_source_simulator/sftp_uploader.py
@@ -161,6 +161,28 @@ class SFTPUploader:
 
         return basename
 
+    def _is_connected(self) -> bool:
+        """Return True if the underlying SSH transport is still active."""
+        if self.sftp is None or self.client is None:
+            return False
+        transport = self.client.get_transport()
+        return transport is not None and transport.is_active()
+
+    def reconnect(self) -> bool:
+        """Close the existing connection and re-establish it. Returns True on success."""
+        logger.info("Attempting SFTP reconnection...")
+        try:
+            self.close()
+        except Exception:
+            pass
+        try:
+            self.connect()
+            logger.info("SFTP reconnected successfully")
+            return True
+        except Exception as e:
+            logger.error(f"SFTP reconnection failed: {e}")
+            return False
+
     def connect(self):
         """Establish SFTP connection with host key verification."""
         try:
@@ -381,11 +403,23 @@ class SFTPUploader:
         Upload all pending CSV files from source directory to SFTP server.
         After successful upload, move files to archive directory.
 
+        If the connection is lost mid-batch a single reconnect is attempted;
+        the current file is retried once and uploading continues.  If the
+        reconnect itself fails the batch is aborted so the files remain in
+        source_dir for the next call.
+
         Returns
         -------
         int
             Number of files successfully uploaded.
         """
+        # Ensure connection is alive before starting
+        if not self._is_connected():
+            logger.warning("SFTP connection not active; attempting reconnect")
+            if not self.reconnect():
+                logger.error("Could not reconnect to SFTP server; skipping upload")
+                return 0
+
         pending_files = self.get_pending_files()
 
         if not pending_files:
@@ -393,6 +427,7 @@ class SFTPUploader:
             return 0
 
         uploaded_count = 0
+        reconnect_attempted = False
 
         for file_path in pending_files:
             try:
@@ -409,12 +444,25 @@ class SFTPUploader:
             except ValueError as e:
                 logger.error(f"Validation error for {file_path.name}: {e}")
                 continue
-            except paramiko.SSHException as e:
-                logger.error(f"SSH error uploading {file_path.name}: {e}")
-                continue
-            except OSError as e:
-                logger.error(f"File operation error for {file_path.name}: {e}")
-                continue
+            except (paramiko.SSHException, OSError) as e:
+                logger.error(f"Connection error uploading {file_path.name}: {e}")
+                if reconnect_attempted:
+                    logger.error("Connection still unstable after reconnect; aborting batch")
+                    break
+                reconnect_attempted = True
+                if not self.reconnect():
+                    logger.error("Reconnect failed; aborting upload batch")
+                    break
+                # Retry this file with the fresh connection
+                try:
+                    self.upload_file(str(file_path))
+                    archive_path = self.archive_dir / file_path.name
+                    shutil.move(str(file_path), str(archive_path))
+                    logger.info(f"Moved {file_path.name} to archive (after reconnect)")
+                    uploaded_count += 1
+                except Exception as retry_e:
+                    logger.error(f"Retry after reconnect failed for {file_path.name}: {retry_e}")
+                    continue
             except Exception as e:
                 logger.error(f"Unexpected error uploading {file_path.name}: {e}")
                 continue

--- a/mno_data_source_simulator/sftp_uploader.py
+++ b/mno_data_source_simulator/sftp_uploader.py
@@ -450,6 +450,8 @@ class SFTPUploader:
                 if reconnect_attempted or not self.reconnect():
                     logger.error("Could not recover connection; aborting batch")
                     break
+                # Mark so the SSHException handler below also aborts rather
+                # than attempting a second reconnect within the same batch.
                 reconnect_attempted = True
             try:
                 # Upload the file

--- a/mno_data_source_simulator/tests/test_sftp_uploader.py
+++ b/mno_data_source_simulator/tests/test_sftp_uploader.py
@@ -452,6 +452,19 @@ def test_reconnect_failure(test_dirs, mock_sftp):
     assert result is False
 
 
+def test_reconnect_close_raises_still_attempts_connect(test_dirs, mock_sftp):
+    """reconnect swallows exceptions from close() and still tries to connect."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    with patch.object(uploader, "close", side_effect=OSError("close error")), \
+         patch.object(uploader, "connect") as mock_connect:
+        result = uploader.reconnect()
+
+    assert result is True
+    mock_connect.assert_called_once()
+
+
 # --- upload_pending_files: upfront connectivity check -----------------------
 
 
@@ -519,6 +532,111 @@ def test_upload_aborts_mid_batch_when_transport_dies(
     # Only the first file uploaded before transport died
     assert count == 1
     assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 2
+
+
+def test_upload_continues_after_successful_mid_batch_reconnect(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """If the transport dies mid-batch but reconnect succeeds, the remaining
+    files are processed normally."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # _is_connected sequence:
+    #   call 1 (upfront)      → True
+    #   call 2 (file 1)       → True   (upload ok)
+    #   call 3 (file 2)       → False  (transport lost)
+    #   call 4 (file 3)       → True   (after reconnect)
+    is_connected_seq = [True, True, False, True]
+    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
+         patch.object(uploader, "reconnect", return_value=True):
+        count = uploader.upload_pending_files()
+
+    assert count == 3
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 0
+
+
+def test_upload_retries_file_after_ssh_exception(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """When sftp.put raises SSHException, the file is retried after reconnect."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    call_count = {"n": 0}
+
+    def put_side_effect(local, remote):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise paramiko.SSHException("socket closed")
+
+    mock_sftp["sftp"].put.side_effect = put_side_effect
+
+    with patch.object(uploader, "reconnect", return_value=True):
+        count = uploader.upload_pending_files()
+
+    # All 3 files should end up uploaded (file 1 via retry, 2+3 normally)
+    assert count == 3
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 0
+
+
+def test_upload_aborts_when_retry_after_ssh_exception_fails(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """If reconnect succeeds but the retry upload also fails, that file is
+    skipped and the batch continues."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    call_count = {"n": 0}
+
+    def put_side_effect(local, remote):
+        call_count["n"] += 1
+        if call_count["n"] <= 2:  # first attempt + retry both fail
+            raise paramiko.SSHException("socket closed")
+
+    mock_sftp["sftp"].put.side_effect = put_side_effect
+
+    with patch.object(uploader, "reconnect", return_value=True):
+        count = uploader.upload_pending_files()
+
+    # File 1 skipped (retry also failed), files 2+3 uploaded
+    assert count == 2
+
+
+def test_upload_aborts_on_second_ssh_exception_after_reconnect(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """If SSHException hits again after a successful reconnect, the batch is
+    aborted immediately (reconnect_attempted guard prevents a second reconnect)."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # Every put() raises SSHException, so the retry after reconnect also fails
+    mock_sftp["sftp"].put.side_effect = paramiko.SSHException("socket closed")
+
+    with patch.object(uploader, "reconnect", return_value=True):
+        count = uploader.upload_pending_files()
+
+    # First file: SSHException → reconnect → retry raises again → continue (0 uploaded)
+    # Second file: SSHException → reconnect_attempted already True → abort
+    assert count == 0
+
+
+def test_upload_aborts_batch_when_ssh_exception_and_reconnect_fails(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """If SSHException is raised and reconnect fails, the batch is aborted."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    mock_sftp["sftp"].put.side_effect = paramiko.SSHException("socket closed")
+
+    with patch.object(uploader, "reconnect", return_value=False):
+        count = uploader.upload_pending_files()
+
+    assert count == 0
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 3
 
 
 # --- max_files_per_call cap --------------------------------------------------

--- a/mno_data_source_simulator/tests/test_sftp_uploader.py
+++ b/mno_data_source_simulator/tests/test_sftp_uploader.py
@@ -359,6 +359,204 @@ def test_upload_continues_on_individual_file_error(
     uploader.close()
 
 
+# ---------------------------------------------------------------------------
+# Tests for resilience features added in fix/mno-simulator-resilience
+# ---------------------------------------------------------------------------
+
+
+def _make_uploader(test_dirs, **kwargs):
+    """Helper to build an SFTPUploader with test directories."""
+    defaults = dict(
+        host="localhost",
+        port=22,
+        username="test_user",
+        password="test_pass",
+        remote_path="/upload",
+        source_dir=test_dirs["source"],
+        archive_dir=test_dirs["archive"],
+    )
+    defaults.update(kwargs)
+    return SFTPUploader(**defaults)
+
+
+# --- _is_connected -----------------------------------------------------------
+
+
+def test_is_connected_no_client(test_dirs):
+    """_is_connected returns False when client/sftp are None."""
+    uploader = _make_uploader(test_dirs)
+    assert uploader._is_connected() is False
+
+
+def test_is_connected_active_transport(test_dirs, mock_sftp):
+    """_is_connected returns True when the transport reports is_active."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    mock_transport = Mock()
+    mock_transport.is_active.return_value = True
+    uploader.client.get_transport.return_value = mock_transport
+
+    assert uploader._is_connected() is True
+    uploader.close()
+
+
+def test_is_connected_inactive_transport(test_dirs, mock_sftp):
+    """_is_connected returns False when the transport is no longer active."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    mock_transport = Mock()
+    mock_transport.is_active.return_value = False
+    uploader.client.get_transport.return_value = mock_transport
+
+    assert uploader._is_connected() is False
+    uploader.close()
+
+
+def test_is_connected_none_transport(test_dirs, mock_sftp):
+    """_is_connected returns False when get_transport() returns None."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+    uploader.client.get_transport.return_value = None
+
+    assert uploader._is_connected() is False
+    uploader.close()
+
+
+# --- reconnect ---------------------------------------------------------------
+
+
+def test_reconnect_success(test_dirs, mock_sftp):
+    """reconnect closes the old connection and opens a new one."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # Patch connect() so the credential-cleared-after-first-connect issue
+    # doesn't interfere; we just want to verify reconnect orchestration.
+    with patch.object(uploader, "connect") as mock_connect:
+        result = uploader.reconnect()
+
+    assert result is True
+    mock_connect.assert_called_once()
+
+
+def test_reconnect_failure(test_dirs, mock_sftp):
+    """reconnect returns False when the new connect() raises."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    mock_sftp["client"].connect.side_effect = OSError("refused")
+    result = uploader.reconnect()
+
+    assert result is False
+
+
+# --- upload_pending_files: upfront connectivity check -----------------------
+
+
+def test_upload_skipped_when_disconnected_and_reconnect_fails(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """upload_pending_files returns 0 without touching files when connection
+    is dead and reconnect also fails."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # Simulate dead transport
+    mock_transport = Mock()
+    mock_transport.is_active.return_value = False
+    uploader.client.get_transport.return_value = mock_transport
+
+    # Reconnect will also fail
+    mock_sftp["client"].connect.side_effect = OSError("refused")
+
+    count = uploader.upload_pending_files()
+
+    assert count == 0
+    mock_sftp["sftp"].put.assert_not_called()
+    # Files must still be in source dir
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 3
+
+
+def test_upload_reconnects_when_disconnected_at_start(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """upload_pending_files reconnects automatically when transport is dead
+    at the start of a batch."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # Upfront check: False → reconnect → then per-file checks: all True
+    is_connected_seq = [False, True, True, True]
+    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
+         patch.object(uploader, "reconnect", return_value=True):
+        count = uploader.upload_pending_files()
+
+    assert count == 3
+
+
+# --- upload_pending_files: per-file mid-batch transport check ---------------
+
+
+def test_upload_aborts_mid_batch_when_transport_dies(
+    test_dirs, sample_csv_files, mock_sftp
+):
+    """If the transport dies mid-batch and reconnect fails, the remaining
+    files are left in source_dir."""
+    uploader = _make_uploader(test_dirs)
+    uploader.connect()
+
+    # _is_connected sequence:
+    #   call 1 (upfront check)     → True  (batch starts normally)
+    #   call 2 (per-file, file 1)  → True  (upload succeeds)
+    #   call 3 (per-file, file 2)  → False (transport died)
+    is_connected_seq = [True, True, False]
+    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
+         patch.object(uploader, "reconnect", return_value=False):
+        count = uploader.upload_pending_files()
+
+    # Only the first file uploaded before transport died
+    assert count == 1
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 2
+
+
+# --- max_files_per_call cap --------------------------------------------------
+
+
+def test_max_files_per_call_limits_batch(test_dirs, sample_csv_files, mock_sftp):
+    """upload_pending_files uploads at most max_files_per_call files per call."""
+    uploader = _make_uploader(test_dirs, max_files_per_call=2)
+    uploader.connect()
+
+    count = uploader.upload_pending_files()
+
+    assert count == 2
+    assert mock_sftp["sftp"].put.call_count == 2
+    # One file must still be in source_dir
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 1
+
+
+def test_max_files_per_call_default_is_200(test_dirs):
+    """Default max_files_per_call is 200."""
+    uploader = _make_uploader(test_dirs)
+    assert uploader.max_files_per_call == 200
+
+
+def test_second_call_processes_remaining_files(test_dirs, sample_csv_files, mock_sftp):
+    """Files left over after a capped batch are picked up on the next call."""
+    uploader = _make_uploader(test_dirs, max_files_per_call=2)
+    uploader.connect()
+
+    first = uploader.upload_pending_files()
+    second = uploader.upload_pending_files()
+
+    assert first == 2
+    assert second == 1
+    assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 0
+
+
+
 def test_remote_directory_creation(test_dirs, mock_sftp):
     """Test that remote directory is created if it doesn't exist."""
     uploader = SFTPUploader(

--- a/parser/db_writer.py
+++ b/parser/db_writer.py
@@ -288,7 +288,7 @@ class DBWriter:
         )
         records = [tuple(x) for x in df_subset.to_numpy()]
 
-        sql = "INSERT INTO cml_data (time, cml_id, sublink_id, rsl, tsl) VALUES %s"
+        sql = "INSERT INTO cml_data (time, cml_id, sublink_id, rsl, tsl) VALUES %s ON CONFLICT (time, cml_id, sublink_id) DO NOTHING"
 
         rows_written = self._with_connection_retry(
             lambda: self._execute_batch_insert(

--- a/parser/main.py
+++ b/parser/main.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from .file_watcher import FileWatcher
 from .file_manager import FileManager
 from .db_writer import DBWriter
-from .service_logic import process_cml_file
+from .service_logic import process_cml_file, process_rawdata_files_batch
 
 
 class Config:
@@ -39,13 +39,26 @@ def setup_logging():
 
 
 def process_existing_files(db_writer, file_manager, logger):
-    incoming = list(Config.INCOMING_DIR.glob("*"))
-    for f in incoming:
-        if f.is_file() and f.suffix.lower() in {".csv"}:
-            try:
-                process_cml_file(f, db_writer, file_manager, logger)
-            except Exception:
-                pass
+    incoming = sorted(
+        f for f in Config.INCOMING_DIR.glob("*.csv") if f.is_file()
+    )
+    if not incoming:
+        return
+
+    metadata_files = [f for f in incoming if "meta" in f.name.lower()]
+    data_files = [f for f in incoming if f not in set(metadata_files)]
+
+    # Metadata files: process individually (typically just one)
+    for f in metadata_files:
+        try:
+            process_cml_file(f, db_writer, file_manager, logger)
+        except Exception:
+            pass
+
+    # Data files: batch-process for efficiency
+    if data_files:
+        logger.info("Found %d data file(s) to process", len(data_files))
+        process_rawdata_files_batch(data_files, db_writer, file_manager, logger)
 
 
 def main():

--- a/parser/service_logic.py
+++ b/parser/service_logic.py
@@ -5,8 +5,82 @@ This module is designed for unit testing and reuse.
 
 from pathlib import Path
 import logging
+from typing import List
+import pandas as pd
 from .parsers.demo_csv_data.parse_raw import parse_rawdata_csv
 from .parsers.demo_csv_data.parse_metadata import parse_metadata_csv
+
+
+def process_rawdata_files_batch(
+    filepaths: List[Path],
+    db_writer,
+    file_manager,
+    logger=None,
+    batch_size: int = 500,
+) -> None:
+    """Process a list of rawdata CSV files in batches.
+
+    Instead of one commit per file, accumulates DataFrames across `batch_size`
+    files and issues a single write + commit per batch.  This is orders of
+    magnitude faster for large backlogs.
+
+    Files that fail to parse are quarantined individually.  If the batch
+    write fails the files remain in the incoming directory so a subsequent
+    restart can retry them.
+    """
+    if logger is None:
+        logger = logging.getLogger("parser.logic")
+
+    total = len(filepaths)
+    logger.info("Batch-processing %d data files (batch_size=%d)", total, batch_size)
+
+    for batch_start in range(0, total, batch_size):
+        batch = filepaths[batch_start : batch_start + batch_size]
+        batch_num = batch_start // batch_size + 1
+
+        dfs: List[pd.DataFrame] = []
+        parsed_files: List[Path] = []
+        failed_files: List[Path] = []
+
+        for filepath in batch:
+            try:
+                df = parse_rawdata_csv(filepath)
+                if df is not None and not df.empty:
+                    dfs.append(df)
+                    parsed_files.append(filepath)
+                else:
+                    failed_files.append(filepath)
+            except Exception:
+                logger.exception("Failed to parse %s, quarantining", filepath.name)
+                failed_files.append(filepath)
+
+        for filepath in failed_files:
+            if filepath.exists():
+                file_manager.quarantine_file(filepath, "Parse error during batch processing")
+
+        if not dfs:
+            logger.info("Batch %d: no parseable files, skipping write", batch_num)
+            continue
+
+        combined = pd.concat(dfs, ignore_index=True)
+        try:
+            db_writer.connect()
+            rows = db_writer.write_rawdata(combined)
+            logger.info(
+                "Batch %d/%d: wrote %d rows from %d files",
+                batch_num,
+                -(-total // batch_size),
+                rows,
+                len(parsed_files),
+            )
+            for filepath in parsed_files:
+                file_manager.archive_file(filepath)
+        except Exception:
+            logger.exception(
+                "Batch %d write failed; %d files remain in incoming for retry",
+                batch_num,
+                len(parsed_files),
+            )
 
 
 def process_cml_file(filepath: Path, db_writer, file_manager, logger=None):

--- a/parser/tests/test_main.py
+++ b/parser/tests/test_main.py
@@ -1,0 +1,120 @@
+"""Tests for process_existing_files in parser/main.py."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+
+from ..main import process_existing_files
+
+
+@pytest.fixture
+def mock_db_writer():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_file_manager():
+    return MagicMock()
+
+
+@pytest.fixture
+def logger():
+    return MagicMock()
+
+
+def _write_csv(directory: Path, name: str) -> Path:
+    p = directory / name
+    p.write_text("time,cml_id,sublink_id,tsl,rsl\n2026-01-01 00:00:00,A,B,1.0,-1.0\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Helpers to patch Config.INCOMING_DIR
+# ---------------------------------------------------------------------------
+
+def _run(tmp_path, db_writer, file_manager, logger):
+    with patch("parser.main.Config.INCOMING_DIR", tmp_path):
+        process_existing_files(db_writer, file_manager, logger)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_files_is_noop(tmp_path, mock_db_writer, mock_file_manager, logger):
+    """Empty incoming directory returns early without calling anything."""
+    _run(tmp_path, mock_db_writer, mock_file_manager, logger)
+
+    mock_db_writer.connect.assert_not_called()
+    mock_file_manager.archive_file.assert_not_called()
+
+
+def test_data_files_only_use_batch_processing(
+    tmp_path, mock_db_writer, mock_file_manager, logger
+):
+    """Data files are forwarded to process_rawdata_files_batch."""
+    files = [_write_csv(tmp_path, f"raw_data_{i}.csv") for i in range(3)]
+
+    with patch("parser.main.process_rawdata_files_batch") as mock_batch, \
+         patch("parser.main.process_cml_file") as mock_single, \
+         patch("parser.main.Config.INCOMING_DIR", tmp_path):
+        process_existing_files(mock_db_writer, mock_file_manager, logger)
+
+    mock_single.assert_not_called()
+    mock_batch.assert_called_once()
+    passed_files = mock_batch.call_args[0][0]
+    assert set(passed_files) == set(files)
+
+
+def test_metadata_files_only_use_individual_processing(
+    tmp_path, mock_db_writer, mock_file_manager, logger
+):
+    """Metadata files are processed individually via process_cml_file."""
+    meta1 = _write_csv(tmp_path, "metadata_links.csv")
+    meta2 = _write_csv(tmp_path, "meta_extra.csv")
+
+    with patch("parser.main.process_rawdata_files_batch") as mock_batch, \
+         patch("parser.main.process_cml_file") as mock_single, \
+         patch("parser.main.Config.INCOMING_DIR", tmp_path):
+        process_existing_files(mock_db_writer, mock_file_manager, logger)
+
+    assert mock_single.call_count == 2
+    mock_batch.assert_not_called()
+
+
+def test_mixed_files_routes_to_correct_handlers(
+    tmp_path, mock_db_writer, mock_file_manager, logger
+):
+    """Metadata files go to process_cml_file; data files go to the batch function."""
+    meta = _write_csv(tmp_path, "metadata_links.csv")
+    data1 = _write_csv(tmp_path, "raw_data_001.csv")
+    data2 = _write_csv(tmp_path, "raw_data_002.csv")
+
+    with patch("parser.main.process_rawdata_files_batch") as mock_batch, \
+         patch("parser.main.process_cml_file") as mock_single, \
+         patch("parser.main.Config.INCOMING_DIR", tmp_path):
+        process_existing_files(mock_db_writer, mock_file_manager, logger)
+
+    mock_single.assert_called_once_with(meta, mock_db_writer, mock_file_manager, logger)
+    mock_batch.assert_called_once()
+    passed_files = mock_batch.call_args[0][0]
+    assert set(passed_files) == {data1, data2}
+
+
+def test_metadata_exception_is_swallowed(
+    tmp_path, mock_db_writer, mock_file_manager, logger
+):
+    """An exception from process_cml_file does not abort processing of remaining files."""
+    meta = _write_csv(tmp_path, "metadata_links.csv")
+    data = _write_csv(tmp_path, "raw_data_001.csv")
+
+    with patch("parser.main.process_cml_file", side_effect=Exception("DB down")) as mock_single, \
+         patch("parser.main.process_rawdata_files_batch") as mock_batch, \
+         patch("parser.main.Config.INCOMING_DIR", tmp_path):
+        process_existing_files(mock_db_writer, mock_file_manager, logger)  # must not raise
+
+    mock_single.assert_called_once()
+    # Batch processing of data files still happens
+    mock_batch.assert_called_once()

--- a/parser/tests/test_service_logic.py
+++ b/parser/tests/test_service_logic.py
@@ -1,0 +1,161 @@
+"""Tests for process_rawdata_files_batch in service_logic."""
+
+import logging
+import pandas as pd
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+from ..service_logic import process_rawdata_files_batch
+
+
+@pytest.fixture
+def mock_db_writer():
+    db = MagicMock()
+    db.write_rawdata.return_value = 10
+    return db
+
+
+@pytest.fixture
+def mock_file_manager():
+    return MagicMock()
+
+
+def _make_raw_csv(tmp_path, name="raw_data.csv", rows=2):
+    """Write a minimal valid rawdata CSV and return its Path."""
+    lines = ["time,cml_id,sublink_id,tsl,rsl"]
+    for i in range(rows):
+        lines.append(f"2026-01-{i+1:02d} 10:00:00,CML_{i},A,{i}.0,-{i}.0")
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_single_batch_writes_and_archives(tmp_path, mock_db_writer, mock_file_manager):
+    """All files in a single batch are written and archived."""
+    files = [_make_raw_csv(tmp_path, f"raw_{i}.csv") for i in range(3)]
+
+    process_rawdata_files_batch(files, mock_db_writer, mock_file_manager)
+
+    mock_db_writer.connect.assert_called_once()
+    mock_db_writer.write_rawdata.assert_called_once()
+    combined = mock_db_writer.write_rawdata.call_args[0][0]
+    assert isinstance(combined, pd.DataFrame)
+    assert len(combined) == 6  # 3 files × 2 rows each
+
+    assert mock_file_manager.archive_file.call_count == 3
+    mock_file_manager.quarantine_file.assert_not_called()
+
+
+def test_multiple_batches(tmp_path, mock_db_writer, mock_file_manager):
+    """Files exceeding batch_size are split into multiple batches."""
+    files = [_make_raw_csv(tmp_path, f"raw_{i}.csv") for i in range(5)]
+
+    process_rawdata_files_batch(
+        files, mock_db_writer, mock_file_manager, batch_size=2
+    )
+
+    # 5 files / batch_size=2 → 3 batches
+    assert mock_db_writer.connect.call_count == 3
+    assert mock_db_writer.write_rawdata.call_count == 3
+    assert mock_file_manager.archive_file.call_count == 5
+
+
+def test_empty_file_list_is_noop(mock_db_writer, mock_file_manager):
+    """An empty file list should not touch the DB or file manager."""
+    process_rawdata_files_batch([], mock_db_writer, mock_file_manager)
+
+    mock_db_writer.connect.assert_not_called()
+    mock_db_writer.write_rawdata.assert_not_called()
+    mock_file_manager.archive_file.assert_not_called()
+    mock_file_manager.quarantine_file.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Parse failures
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_file_is_quarantined(tmp_path, mock_db_writer, mock_file_manager):
+    """A file that raises during parsing is quarantined; others proceed."""
+    good = _make_raw_csv(tmp_path, "good.csv")
+    bad = tmp_path / "bad.csv"
+    bad.write_text("not,a,valid,csv\n???\n")
+
+    with patch(
+        "parser.service_logic.parse_rawdata_csv",
+        side_effect=lambda p: (_ for _ in ()).throw(ValueError("bad csv"))
+        if p == bad
+        else pd.read_csv(p),
+    ):
+        process_rawdata_files_batch(
+            [good, bad], mock_db_writer, mock_file_manager
+        )
+
+    mock_file_manager.quarantine_file.assert_called_once_with(
+        bad, "Parse error during batch processing"
+    )
+    mock_file_manager.archive_file.assert_called_once_with(good)
+
+
+def test_file_returning_none_is_quarantined(tmp_path, mock_db_writer, mock_file_manager):
+    """A file whose parser returns None is quarantined."""
+    f = _make_raw_csv(tmp_path, "raw.csv")
+
+    with patch("parser.service_logic.parse_rawdata_csv", return_value=None):
+        process_rawdata_files_batch([f], mock_db_writer, mock_file_manager)
+
+    mock_file_manager.quarantine_file.assert_called_once_with(
+        f, "Parse error during batch processing"
+    )
+    mock_db_writer.write_rawdata.assert_not_called()
+
+
+def test_file_returning_empty_df_is_quarantined(tmp_path, mock_db_writer, mock_file_manager):
+    """A file whose parser returns an empty DataFrame is quarantined."""
+    f = _make_raw_csv(tmp_path, "raw.csv")
+
+    with patch(
+        "parser.service_logic.parse_rawdata_csv",
+        return_value=pd.DataFrame(),
+    ):
+        process_rawdata_files_batch([f], mock_db_writer, mock_file_manager)
+
+    mock_file_manager.quarantine_file.assert_called_once_with(
+        f, "Parse error during batch processing"
+    )
+    mock_db_writer.write_rawdata.assert_not_called()
+
+
+def test_all_files_fail_parse_skips_write(tmp_path, mock_db_writer, mock_file_manager):
+    """When every file in a batch fails to parse, the DB write is skipped."""
+    files = [_make_raw_csv(tmp_path, f"raw_{i}.csv") for i in range(3)]
+
+    with patch("parser.service_logic.parse_rawdata_csv", return_value=None):
+        process_rawdata_files_batch(files, mock_db_writer, mock_file_manager)
+
+    mock_db_writer.write_rawdata.assert_not_called()
+    assert mock_file_manager.quarantine_file.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# DB write failure
+# ---------------------------------------------------------------------------
+
+
+def test_db_write_failure_leaves_files_in_place(
+    tmp_path, mock_db_writer, mock_file_manager
+):
+    """If the DB write raises, files are NOT archived (available for retry)."""
+    files = [_make_raw_csv(tmp_path, f"raw_{i}.csv") for i in range(2)]
+    mock_db_writer.write_rawdata.side_effect = Exception("DB down")
+
+    process_rawdata_files_batch(files, mock_db_writer, mock_file_manager)
+
+    mock_file_manager.archive_file.assert_not_called()
+    mock_file_manager.quarantine_file.assert_not_called()


### PR DESCRIPTION
## fix/mno-simulator-resilience

### Simulator resilience
`SFTPUploader` now checks connection liveness before and during each batch
(`_is_connected()` / `reconnect()`). A dead socket triggers a single
reconnect attempt rather than buffering every pending file against it —
the root cause of the OOM kill on April 12. `restart: unless-stopped` added
to `docker-compose.yml` so the container recovers without manual intervention.

### Backlog cap
`upload_pending_files` processes at most `max_files_per_call=200` files per
call. `last_upload_time` now always advances after an upload attempt, so a
persistent connection failure no longer causes every 10-second loop to retry
the full backlog.

### Idempotent ingestion
`cml_data` gains a `UNIQUE (time, cml_id, sublink_id, user_id)` constraint
(compatible with `feat/db-add-user-id`). The parser's `write_rawdata` uses
`ON CONFLICT DO NOTHING`, so replaying files produces no duplicates.

### Startup batch processing
`process_existing_files` routes data files through `process_rawdata_files_batch`
(500 files per DB commit) instead of one commit per file, cutting startup
time for large backlogs by orders of magnitude.

### Test coverage
43 new unit tests across `test_sftp_uploader.py`, `test_service_logic.py`,
and `test_main.py`, covering all branch-new code paths: reconnection logic,
batch cap, parse failures, DB write failures, and startup file routing.