### PR TITLE
Feat/remove redundant simulator archive; gzip parser archive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     volumes:
       - ./parser/example_data:/app/example_data  # writable so the file can be downloaded
       - mno_openmrg_data_to_upload:/app/data_to_upload
-      - mno_openmrg_data_uploaded:/app/data_uploaded
       - ./ssh_keys:/app/ssh_keys:ro
     environment:
       - NETCDF_FILE=${OPENMRG_NETCDF_FILE:-/app/example_data/openMRG_cmls_20150827_3months.nc}
@@ -53,7 +52,6 @@ services:
     volumes:
       - ./parser/example_data:/app/example_data:ro
       - mno_orange_cameroun_data_to_upload:/app/data_to_upload
-      - mno_orange_cameroun_data_uploaded:/app/data_uploaded
       - ./ssh_keys:/app/ssh_keys:ro
     environment:
       - NETCDF_FILE=/app/example_data/cml_raw_douala.nc
@@ -275,7 +273,5 @@ volumes:
   webserver_data_archived:
   grafana_data:
   mno_openmrg_data_to_upload:
-  mno_openmrg_data_uploaded:
   mno_orange_cameroun_data_to_upload:
-  mno_orange_cameroun_data_uploaded:
   # minio_data:  # Uncomment if using MinIO

--- a/mno_data_source_simulator/Dockerfile
+++ b/mno_data_source_simulator/Dockerfile
@@ -17,7 +17,7 @@ COPY config.yml .
 RUN mkdir -p /app/example_data
 
 # Create directories for data management
-RUN mkdir -p /app/data_to_upload /app/data_uploaded
+RUN mkdir -p /app/data_to_upload
 
 # Run the application
 CMD ["python", "main.py"]

--- a/mno_data_source_simulator/README.md
+++ b/mno_data_source_simulator/README.md
@@ -13,15 +13,13 @@ Simulates a Mobile Network Operator (MNO) data source by reading CML data from N
 
 **Modules:**
 - `data_generator.py` - Reads NetCDF, generates CSV files with current timestamps
-- `sftp_uploader.py` - Uploads files via SFTP, archives after successful upload
+- `sftp_uploader.py` - Uploads files via SFTP, deletes local file after successful upload
 - `main.py` - Orchestrates generation and upload
 
 **Data Flow:**
 1. Generate CSV → `data_to_upload/`
 2. Upload to SFTP server
-3. Move to `data_uploaded/` archive
-
-Benefits: Local inspection, resilient to upload failures, manual upload capability.
+3. Delete local file after successful upload
 
 ## Quick Start
 
@@ -118,7 +116,7 @@ ssh-keyscan -p 22 sftp.example.com >> ~/.ssh/known_hosts
 ## Inspecting Data
 
 ```bash
-# View generated files
+# View files waiting to be uploaded
 ls data_to_upload/
 
 # With Docker

--- a/mno_data_source_simulator/TESTING.md
+++ b/mno_data_source_simulator/TESTING.md
@@ -10,7 +10,7 @@
 
 ### ✅ Unit Tests (`tests/test_sftp_uploader.py`, `tests/test_generator.py`, `tests/test_sftp_security.py`, `tests/test_main_auth.py`)
 - 48 total unit tests covering:
-  - SFTP uploader functionality (connection, uploads, error handling, file archiving)
+  - SFTP uploader functionality (connection, uploads, error handling, post-upload deletion)
   - Data generator (CSV generation, metadata, timestamp handling)
   - Security features (path validation, filename sanitization, authentication methods, host key verification, timeouts)
   - Authentication validation (password vs SSH key, explicit configuration)

--- a/mno_data_source_simulator/config.yml
+++ b/mno_data_source_simulator/config.yml
@@ -46,5 +46,3 @@ generator:
 file_management:
   # Directory for files waiting to be uploaded
   source_dir: "data_to_upload"
-  # Directory for files that have been uploaded
-  archive_dir: "data_uploaded"

--- a/mno_data_source_simulator/main.py
+++ b/mno_data_source_simulator/main.py
@@ -123,7 +123,6 @@ def main():
                     known_hosts_path=known_hosts,
                     remote_path=config["sftp"]["remote_path"],
                     source_dir=config["file_management"]["source_dir"],
-                    archive_dir=config["file_management"]["archive_dir"],
                     connection_timeout=config["sftp"].get("connection_timeout", 30),
                 )
                 sftp_uploader.connect()

--- a/mno_data_source_simulator/sftp_uploader.py
+++ b/mno_data_source_simulator/sftp_uploader.py
@@ -7,7 +7,6 @@ This module handles uploading CML data to an SFTP server.
 import paramiko
 import io
 import logging
-import shutil
 import re
 import os
 from datetime import datetime
@@ -31,7 +30,6 @@ class SFTPUploader:
         known_hosts_path: Optional[str] = None,
         remote_path: str = "/upload",
         source_dir: str = "data_to_upload",
-        archive_dir: str = "data_uploaded",
         connection_timeout: int = 30,
         max_files_per_call: int = 200,
     ):
@@ -57,8 +55,6 @@ class SFTPUploader:
             Remote directory path where files will be uploaded.
         source_dir : str, optional
             Local directory to read files from (default: "data_to_upload").
-        archive_dir : str, optional
-            Local directory to move uploaded files to (default: "data_uploaded").
         connection_timeout : int, optional
             Connection timeout in seconds (default: 30).
         """
@@ -79,15 +75,12 @@ class SFTPUploader:
         self.remote_path = self._validate_remote_path(remote_path)
 
         self.source_dir = Path(source_dir)
-        self.archive_dir = Path(archive_dir)
         self.client: Optional[paramiko.SSHClient] = None
         self.sftp: Optional[paramiko.SFTPClient] = None
 
         # Create directories if they don't exist
         self.source_dir.mkdir(parents=True, exist_ok=True)
-        self.archive_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Source directory: {self.source_dir}")
-        logger.info(f"Archive directory: {self.archive_dir}")
 
     def _validate_remote_path(self, path: str) -> str:
         """
@@ -405,7 +398,7 @@ class SFTPUploader:
     def upload_pending_files(self) -> int:
         """
         Upload all pending CSV files from source directory to SFTP server.
-        After successful upload, move files to archive directory.
+        After successful upload, delete files from the source directory.
 
         If the connection is lost mid-batch a single reconnect is attempted;
         the current file is retried once and uploading continues.  If the
@@ -457,10 +450,9 @@ class SFTPUploader:
                 # Upload the file
                 remote_file_path = self.upload_file(str(file_path))
 
-                # Move to archive directory
-                archive_path = self.archive_dir / file_path.name
-                shutil.move(str(file_path), str(archive_path))
-                logger.info(f"Moved {file_path.name} to archive")
+                # Delete after successful upload
+                file_path.unlink()
+                logger.info(f"Deleted {file_path.name} after upload")
 
                 uploaded_count += 1
 
@@ -479,9 +471,8 @@ class SFTPUploader:
                 # Retry this file with the fresh connection
                 try:
                     self.upload_file(str(file_path))
-                    archive_path = self.archive_dir / file_path.name
-                    shutil.move(str(file_path), str(archive_path))
-                    logger.info(f"Moved {file_path.name} to archive (after reconnect)")
+                    file_path.unlink()
+                    logger.info(f"Deleted {file_path.name} after upload (after reconnect)")
                     uploaded_count += 1
                 except Exception as retry_e:
                     logger.error(f"Retry after reconnect failed for {file_path.name}: {retry_e}")

--- a/mno_data_source_simulator/sftp_uploader.py
+++ b/mno_data_source_simulator/sftp_uploader.py
@@ -462,7 +462,9 @@ class SFTPUploader:
             except (paramiko.SSHException, OSError) as e:
                 logger.error(f"Connection error uploading {file_path.name}: {e}")
                 if reconnect_attempted:
-                    logger.error("Connection still unstable after reconnect; aborting batch")
+                    logger.error(
+                        "Connection still unstable after reconnect; aborting batch"
+                    )
                     break
                 reconnect_attempted = True
                 if not self.reconnect():
@@ -472,10 +474,14 @@ class SFTPUploader:
                 try:
                     self.upload_file(str(file_path))
                     file_path.unlink()
-                    logger.info(f"Deleted {file_path.name} after upload (after reconnect)")
+                    logger.info(
+                        f"Deleted {file_path.name} after upload (after reconnect)"
+                    )
                     uploaded_count += 1
                 except Exception as retry_e:
-                    logger.error(f"Retry after reconnect failed for {file_path.name}: {retry_e}")
+                    logger.error(
+                        f"Retry after reconnect failed for {file_path.name}: {retry_e}"
+                    )
                     continue
             except Exception as e:
                 logger.error(f"Unexpected error uploading {file_path.name}: {e}")

--- a/mno_data_source_simulator/tests/integration/test_sftp_integration.py
+++ b/mno_data_source_simulator/tests/integration/test_sftp_integration.py
@@ -50,15 +50,12 @@ def test_dirs():
     """Create temporary directories for testing."""
     tmp_base = tempfile.mkdtemp()
     source_dir = Path(tmp_base) / "data_to_upload"
-    archive_dir = Path(tmp_base) / "data_uploaded"
 
     source_dir.mkdir(parents=True, exist_ok=True)
-    archive_dir.mkdir(parents=True, exist_ok=True)
 
     yield {
         "base": tmp_base,
         "source": str(source_dir),
-        "archive": str(archive_dir),
     }
 
     shutil.rmtree(tmp_base)
@@ -100,7 +97,6 @@ def test_real_sftp_connection(test_dirs):
         known_hosts_path=KNOWN_HOSTS_PATH,
         remote_path=SFTP_REMOTE_PATH,
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     # This will fail if SFTP server is not running
@@ -123,7 +119,6 @@ def test_real_sftp_upload_file(test_dirs, sample_csv_files):
         known_hosts_path=KNOWN_HOSTS_PATH,
         remote_path=SFTP_REMOTE_PATH,
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     try:
@@ -160,7 +155,6 @@ def test_real_sftp_upload_pending_files(test_dirs, sample_csv_files):
         known_hosts_path=KNOWN_HOSTS_PATH,
         remote_path=SFTP_REMOTE_PATH,
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     try:
@@ -171,12 +165,9 @@ def test_real_sftp_upload_pending_files(test_dirs, sample_csv_files):
 
         assert count == 3
 
-        # Verify files were moved to archive
+        # Verify files were deleted from source
         source_files = list(Path(test_dirs["source"]).glob("*.csv"))
-        archive_files = list(Path(test_dirs["archive"]).glob("*.csv"))
-
         assert len(source_files) == 0
-        assert len(archive_files) == 3
 
         # Verify files exist on server
         for filepath in sample_csv_files:
@@ -206,7 +197,6 @@ def test_real_sftp_context_manager(test_dirs, sample_csv_files):
             known_hosts_path=KNOWN_HOSTS_PATH,
             remote_path=SFTP_REMOTE_PATH,
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         ) as uploader:
             # Upload a file
             local_file = sample_csv_files[0]

--- a/mno_data_source_simulator/tests/test_sftp_security.py
+++ b/mno_data_source_simulator/tests/test_sftp_security.py
@@ -18,15 +18,12 @@ def test_dirs():
     """Create temporary directories for testing."""
     tmp_base = tempfile.mkdtemp()
     source_dir = Path(tmp_base) / "data_to_upload"
-    archive_dir = Path(tmp_base) / "data_uploaded"
 
     source_dir.mkdir(parents=True, exist_ok=True)
-    archive_dir.mkdir(parents=True, exist_ok=True)
 
     yield {
         "base": tmp_base,
         "source": str(source_dir),
-        "archive": str(archive_dir),
     }
 
     shutil.rmtree(tmp_base)
@@ -44,7 +41,6 @@ class TestPathValidation:
             password="pass",
             remote_path="/upload/data",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         assert uploader.remote_path == "/upload/data"
 
@@ -58,7 +54,6 @@ class TestPathValidation:
                 password="pass",
                 remote_path="upload/data",  # No leading /
                 source_dir=test_dirs["source"],
-                archive_dir=test_dirs["archive"],
             )
 
     def test_reject_path_traversal(self, test_dirs):
@@ -71,7 +66,6 @@ class TestPathValidation:
                 password="pass",
                 remote_path="/upload/../../../etc",
                 source_dir=test_dirs["source"],
-                archive_dir=test_dirs["archive"],
             )
 
     def test_reject_invalid_characters(self, test_dirs):
@@ -84,7 +78,6 @@ class TestPathValidation:
                 password="pass",
                 remote_path="/upload/data;rm -rf /",
                 source_dir=test_dirs["source"],
-                archive_dir=test_dirs["archive"],
             )
 
     def test_path_normalization(self, test_dirs):
@@ -96,7 +89,6 @@ class TestPathValidation:
             password="pass",
             remote_path="/upload//data",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         # Should normalize double slashes
         assert uploader.remote_path == "/upload/data"
@@ -114,7 +106,6 @@ class TestFilenameValidation:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         result = uploader._sanitize_filename("data_file.csv")
         assert result == "data_file.csv"
@@ -128,7 +119,6 @@ class TestFilenameValidation:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         with pytest.raises(ValueError, match="Invalid filename"):
             uploader._sanitize_filename("../etc/passwd")
@@ -145,7 +135,6 @@ class TestFilenameValidation:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         with pytest.raises(ValueError, match="Hidden files not allowed"):
             uploader._sanitize_filename(".hidden_file.csv")
@@ -159,7 +148,6 @@ class TestFilenameValidation:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
         with pytest.raises(ValueError, match="invalid characters"):
             uploader._sanitize_filename("file;rm -rf.csv")
@@ -192,7 +180,6 @@ class TestAuthenticationMethods:
                 private_key_path=str(key_file),
                 remote_path="/upload",
                 source_dir=test_dirs["source"],
-                archive_dir=test_dirs["archive"],
             )
 
             uploader.connect()
@@ -224,7 +211,6 @@ class TestAuthenticationMethods:
             password="secret_pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         uploader.connect()
@@ -249,7 +235,6 @@ class TestAuthenticationMethods:
             # No password or private_key_path
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         with pytest.raises(ValueError, match="Either password or private_key_path"):
@@ -272,7 +257,6 @@ class TestAuthenticationMethods:
                 private_key_path="/invalid/key/path",
                 remote_path="/upload",
                 source_dir=test_dirs["source"],
-                archive_dir=test_dirs["archive"],
             )
 
             with pytest.raises(ValueError, match="Invalid private key file"):
@@ -298,7 +282,6 @@ class TestHostKeyVerification:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         uploader.connect()
@@ -330,7 +313,6 @@ class TestHostKeyVerification:
             known_hosts_path=str(known_hosts),
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         uploader.connect()
@@ -360,7 +342,6 @@ class TestConnectionTimeout:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         uploader.connect()
@@ -388,7 +369,6 @@ class TestConnectionTimeout:
             connection_timeout=60,
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         uploader.connect()
@@ -419,7 +399,6 @@ class TestExceptionHandling:
             password="wrong_pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         with pytest.raises(paramiko.AuthenticationException):
@@ -439,7 +418,6 @@ class TestExceptionHandling:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         with pytest.raises(paramiko.SSHException):
@@ -459,7 +437,6 @@ class TestExceptionHandling:
             password="pass",
             remote_path="/upload",
             source_dir=test_dirs["source"],
-            archive_dir=test_dirs["archive"],
         )
 
         with pytest.raises(OSError):

--- a/mno_data_source_simulator/tests/test_sftp_uploader.py
+++ b/mno_data_source_simulator/tests/test_sftp_uploader.py
@@ -438,8 +438,9 @@ def test_reconnect_close_raises_still_attempts_connect(test_dirs, mock_sftp):
     uploader = _make_uploader(test_dirs)
     uploader.connect()
 
-    with patch.object(uploader, "close", side_effect=OSError("close error")), \
-         patch.object(uploader, "connect") as mock_connect:
+    with patch.object(
+        uploader, "close", side_effect=OSError("close error")
+    ), patch.object(uploader, "connect") as mock_connect:
         result = uploader.reconnect()
 
     assert result is True
@@ -483,8 +484,9 @@ def test_upload_reconnects_when_disconnected_at_start(
 
     # Upfront check: False → reconnect → then per-file checks: all True
     is_connected_seq = [False, True, True, True]
-    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
-         patch.object(uploader, "reconnect", return_value=True):
+    with patch.object(
+        uploader, "_is_connected", side_effect=is_connected_seq
+    ), patch.object(uploader, "reconnect", return_value=True):
         count = uploader.upload_pending_files()
 
     assert count == 3
@@ -506,8 +508,9 @@ def test_upload_aborts_mid_batch_when_transport_dies(
     #   call 2 (per-file, file 1)  → True  (upload succeeds)
     #   call 3 (per-file, file 2)  → False (transport died)
     is_connected_seq = [True, True, False]
-    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
-         patch.object(uploader, "reconnect", return_value=False):
+    with patch.object(
+        uploader, "_is_connected", side_effect=is_connected_seq
+    ), patch.object(uploader, "reconnect", return_value=False):
         count = uploader.upload_pending_files()
 
     # Only the first file uploaded before transport died
@@ -529,8 +532,9 @@ def test_upload_continues_after_successful_mid_batch_reconnect(
     #   call 3 (file 2)       → False  (transport lost)
     #   call 4 (file 3)       → True   (after reconnect)
     is_connected_seq = [True, True, False, True]
-    with patch.object(uploader, "_is_connected", side_effect=is_connected_seq), \
-         patch.object(uploader, "reconnect", return_value=True):
+    with patch.object(
+        uploader, "_is_connected", side_effect=is_connected_seq
+    ), patch.object(uploader, "reconnect", return_value=True):
         count = uploader.upload_pending_files()
 
     assert count == 3
@@ -653,7 +657,6 @@ def test_second_call_processes_remaining_files(test_dirs, sample_csv_files, mock
     assert first == 2
     assert second == 1
     assert len(list(Path(test_dirs["source"]).glob("*.csv"))) == 0
-
 
 
 def test_remote_directory_creation(test_dirs, mock_sftp):

--- a/mno_data_source_simulator/tests/test_sftp_uploader.py
+++ b/mno_data_source_simulator/tests/test_sftp_uploader.py
@@ -19,15 +19,12 @@ def test_dirs():
     """Create temporary directories for testing."""
     tmp_base = tempfile.mkdtemp()
     source_dir = Path(tmp_base) / "data_to_upload"
-    archive_dir = Path(tmp_base) / "data_uploaded"
 
     source_dir.mkdir(parents=True, exist_ok=True)
-    archive_dir.mkdir(parents=True, exist_ok=True)
 
     yield {
         "base": tmp_base,
         "source": str(source_dir),
-        "archive": str(archive_dir),
     }
 
     shutil.rmtree(tmp_base)
@@ -95,7 +92,6 @@ def test_uploader_initialization(test_dirs):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     assert uploader.host == "localhost"
@@ -103,7 +99,6 @@ def test_uploader_initialization(test_dirs):
     assert uploader.username == "test_user"
     assert uploader.remote_path == "/upload"
     assert uploader.source_dir.exists()
-    assert uploader.archive_dir.exists()
 
 
 def test_uploader_connection(test_dirs, mock_sftp):
@@ -115,7 +110,6 @@ def test_uploader_connection(test_dirs, mock_sftp):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()
@@ -149,7 +143,6 @@ def test_get_pending_files(test_dirs, sample_csv_files):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     pending = uploader.get_pending_files()
@@ -168,7 +161,6 @@ def test_get_pending_files_empty(test_dirs):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     pending = uploader.get_pending_files()
@@ -184,7 +176,6 @@ def test_upload_file(test_dirs, sample_csv_files, mock_sftp):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()
@@ -209,7 +200,6 @@ def test_upload_dataframe_as_csv(test_dirs, mock_sftp):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()
@@ -248,7 +238,6 @@ def test_upload_pending_files(test_dirs, sample_csv_files, mock_sftp):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()
@@ -260,12 +249,9 @@ def test_upload_pending_files(test_dirs, sample_csv_files, mock_sftp):
     assert count == 3
     assert mock_sftp["sftp"].put.call_count == 3
 
-    # Verify files were moved to archive
+    # Verify files were deleted from source
     source_files = list(Path(test_dirs["source"]).glob("*.csv"))
-    archive_files = list(Path(test_dirs["archive"]).glob("*.csv"))
-
     assert len(source_files) == 0
-    assert len(archive_files) == 3
 
     uploader.close()
 
@@ -279,7 +265,6 @@ def test_upload_pending_files_no_connection(test_dirs, sample_csv_files):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     # Try to upload without connecting
@@ -296,7 +281,6 @@ def test_context_manager(test_dirs, mock_sftp):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     ) as uploader:
         # Verify connection was established
         assert uploader.sftp is not None
@@ -315,7 +299,6 @@ def test_upload_with_connection_error(test_dirs):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     # Should raise exception on connection failure
@@ -334,7 +317,6 @@ def test_upload_continues_on_individual_file_error(
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()
@@ -373,7 +355,6 @@ def _make_uploader(test_dirs, **kwargs):
         password="test_pass",
         remote_path="/upload",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
     defaults.update(kwargs)
     return SFTPUploader(**defaults)
@@ -684,7 +665,6 @@ def test_remote_directory_creation(test_dirs, mock_sftp):
         password="test_pass",
         remote_path="/upload/cml_data",
         source_dir=test_dirs["source"],
-        archive_dir=test_dirs["archive"],
     )
 
     uploader.connect()

--- a/parser/README.md
+++ b/parser/README.md
@@ -6,7 +6,7 @@ Parses CML CSV files uploaded via SFTP and writes to the Postgres/TimescaleDB da
 
 - Auto-processes CSV files: `cml_data_*.csv` → `cml_data` table, `cml_metadata_*.csv` → `cml_metadata` table
 - Ingests raw data even when metadata is missing (logs warnings for missing IDs)
-- Archives successful files to `archived/YYYY-MM-DD/`, quarantines failures with `.error.txt` notes
+- Archives successful files to `archived/YYYY-MM-DD/` as `.csv.gz`, quarantines failures with `.error.txt` notes
 - Plugin-style parsers for extensibility
 - DB connection retry with exponential backoff
 - Cross-device file move fallback (move → copy)
@@ -118,5 +118,5 @@ pytest parser/tests/ -v
 - Check quarantine dir for `.error.txt` notes
 - Review logs for DB connection or parse errors
 
-**Archived files:** `/app/data/archived/YYYY-MM-DD/filename.csv`  
+**Archived files:** `/app/data/archived/YYYY-MM-DD/filename.csv.gz`  
 **Quarantine notes:** `/app/data/quarantine/filename.csv.error.txt`

--- a/parser/file_manager.py
+++ b/parser/file_manager.py
@@ -5,6 +5,7 @@ an accompanying `.error.txt` that contains failure details.
 """
 
 from pathlib import Path
+import gzip
 import shutil
 import datetime
 import logging
@@ -43,14 +44,20 @@ class FileManager:
                 return False
 
     def archive_file(self, filepath: Path) -> Path:
-        """Move `filepath` to archive/YYYY-MM-DD/ and return destination path."""
+        """Gzip-compress `filepath` into archive/YYYY-MM-DD/ and return destination path."""
         filepath = Path(filepath)
         if not filepath.exists():
             raise FileNotFoundError(f"File not found: {filepath}")
 
         dest_dir = self._archive_subdir()
-        dest = dest_dir / filepath.name
-        if not self._safe_move(filepath, dest):
+        dest = dest_dir / (filepath.name + ".gz")
+        try:
+            with filepath.open("rb") as f_in, gzip.open(dest, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            filepath.unlink()
+            logger.info(f"Archived (gzip) {filepath} → {dest}")
+        except Exception:
+            dest.unlink(missing_ok=True)
             raise RuntimeError(f"Failed to archive file {filepath}")
         return dest
 
@@ -94,4 +101,4 @@ class FileManager:
     def get_archived_path(self, filepath: Path) -> Path:
         """Return the destination archive path for a given filepath (without moving)."""
         subdir = self._archive_subdir()
-        return subdir / Path(filepath).name
+        return subdir / (Path(filepath).name + ".gz")

--- a/parser/tests/test_file_manager.py
+++ b/parser/tests/test_file_manager.py
@@ -18,6 +18,7 @@ def test_archive_and_quarantine(tmp_path):
 
     archived_path = fm.archive_file(f)
     assert archived_path.exists()
+    assert archived_path.suffix == ".gz"
     assert not f.exists()
 
     # create a file to quarantine

--- a/parser/tests/test_file_manager_extended.py
+++ b/parser/tests/test_file_manager_extended.py
@@ -31,34 +31,32 @@ def test_quarantine_file_not_found(tmp_path):
 def test_safe_move_fallback_to_copy(tmp_path):
     """Test _safe_move falls back to copy when move fails."""
     incoming = tmp_path / "incoming"
-    archived = tmp_path / "archived"
     quarantine = tmp_path / "quarantine"
     incoming.mkdir()
 
-    fm = FileManager(str(incoming), str(archived), str(quarantine))
+    fm = FileManager(str(incoming), str(tmp_path / "archived"), str(quarantine))
 
     f = incoming / "test.csv"
     f.write_text("data")
 
-    # Mock shutil.move to fail, copy2 to succeed
+    # _safe_move is used by quarantine_file; verify fallback via that path
     with patch("parser.file_manager.shutil.move") as mock_move:
         mock_move.side_effect = OSError("Cross-device link")
 
-        dest = fm.archive_file(f)
+        dest = fm.quarantine_file(f, "parse error")
 
-        assert dest.exists()
-        # File should be copied since move failed
+        # File should have been copied since move failed
+        assert (quarantine / "test.csv").exists()
         mock_move.assert_called_once()
 
 
 def test_safe_move_both_fail(tmp_path):
-    """Test archive fails when both move and copy fail."""
+    """Test quarantine fails gracefully when both move and copy fail."""
     incoming = tmp_path / "incoming"
-    archived = tmp_path / "archived"
     quarantine = tmp_path / "quarantine"
     incoming.mkdir()
 
-    fm = FileManager(str(incoming), str(archived), str(quarantine))
+    fm = FileManager(str(incoming), str(tmp_path / "archived"), str(quarantine))
 
     f = incoming / "test.csv"
     f.write_text("data")
@@ -68,8 +66,9 @@ def test_safe_move_both_fail(tmp_path):
             mock_move.side_effect = OSError("Move failed")
             mock_copy.side_effect = OSError("Copy failed")
 
-            with pytest.raises(RuntimeError, match="Failed to archive"):
-                fm.archive_file(f)
+            # quarantine_file falls back to an orphan note rather than raising
+            result = fm.quarantine_file(f, "parse error")
+            assert ".orphan" in result.name or ".error.txt" in result.name
 
 
 def test_quarantine_creates_orphan_on_move_copy_failure(tmp_path):
@@ -101,7 +100,7 @@ def test_get_archived_path(tmp_path):
 
     path = fm.get_archived_path(Path("test.csv"))
 
-    assert "test.csv" in str(path)
+    assert "test.csv.gz" in str(path)
     assert not path.exists()  # File not actually moved
 
 


### PR DESCRIPTION
## feat: remove redundant simulator archive; gzip parser archive

### Summary

Two storage improvements on top of `main`:

**1. Remove MNO simulator `data_uploaded` archive**

Files in `data_to_upload/` are now deleted immediately after a successful
SFTP upload instead of being moved to a local `data_uploaded/` directory.
The parser-side archive is the single authoritative copy.

- `sftp_uploader.py` — replace `shutil.move` → `file_path.unlink()`; remove
  `archive_dir` param, attribute, and `import shutil`
- `config.yml` — remove `archive_dir` key
- `main.py` — remove `archive_dir` kwarg
- `Dockerfile` — remove `/app/data_uploaded` from `mkdir`
- `docker-compose.yml` — remove `mno_*_data_uploaded` volume mounts and
  declarations

**2. Gzip-compress parser archive files**

`FileManager.archive_file()` now writes `<name>.csv.gz` (via `gzip.open` +
`shutil.copyfileobj`) and unlinks the original, instead of moving the plain
CSV. Typical compression ratio 5–10×. Quarantine files remain uncompressed
for easy inspection. Partial `.gz` files are cleaned up on failure.

- `file_manager.py` — add `import gzip`; rewrite `archive_file()`; update
  `get_archived_path()` to return `.gz` path

### Tests

All existing tests updated and passing (50 simulator + 62 parser).

### Docs updated

`mno_data_source_simulator/README.md`, `mno_data_source_simulator/TESTING.md`,
`parser/README.md`