### PR TITLE
fix: grafana startup crash and orange_cameroun SFTP key path

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -301,6 +301,7 @@ ALTER TABLE file_processing_log FORCE ROW LEVEL SECURITY;
 CREATE POLICY user_isolation ON file_processing_log
     USING (user_id = current_user);
 
-GRANT SELECT ON file_processing_log TO demo_openmrg, demo_orange_cameroun, webserver_role;
+GRANT SELECT, INSERT ON file_processing_log TO demo_openmrg, demo_orange_cameroun;
+GRANT SELECT            ON file_processing_log TO webserver_role;
 GRANT USAGE ON SEQUENCE file_processing_log_id_seq TO demo_openmrg, demo_orange_cameroun;
 GRANT SELECT ON cml_data_1h_secure TO webserver_role;

--- a/database/migrations/008_add_file_processing_log.sql
+++ b/database/migrations/008_add_file_processing_log.sql
@@ -22,19 +22,18 @@ CREATE INDEX IF NOT EXISTS file_processing_log_status_time_idx
     ON file_processing_log (status, processed_at DESC);
 
 -- Row-Level Security: each login role only sees its own rows (user_id = current_user).
--- myuser (superuser) bypasses RLS so the parser continues to INSERT without restriction.
+-- The parser connects as the per-user role, so RLS is enforced; INSERT is permitted
+-- because the user_id column must equal current_user (guaranteed by the parser).
 ALTER TABLE file_processing_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE file_processing_log FORCE ROW LEVEL SECURITY;
 CREATE POLICY user_isolation ON file_processing_log
     USING (user_id = current_user);
 
--- Grant read access to all user roles so Grafana dashboards can query this table.
--- Each role connects to Postgres as their own login (demo_openmrg, demo_orange_cameroun)
--- and Grafana reads the log for that org's datasource.
--- webserver_role needs it for any admin views.
-GRANT SELECT ON file_processing_log TO demo_openmrg, demo_orange_cameroun, webserver_role;
+-- Grant read+write access to user roles: the parser connects as the per-user
+-- role (e.g. demo_openmrg) and INSERTs a log entry for every processed file.
+-- webserver_role only needs SELECT (read-only admin/dashboard view).
+GRANT SELECT, INSERT ON file_processing_log TO demo_openmrg, demo_orange_cameroun;
+GRANT SELECT            ON file_processing_log TO webserver_role;
 
--- Sequence used by the BIGSERIAL primary key: needed for INSERTs by the parser
--- (which connects as myuser/superuser, so this is a no-op in practice,
--- but keeps the intent explicit for future role changes).
+-- Sequence used by the BIGSERIAL primary key: required for INSERT by user roles.
 GRANT USAGE ON SEQUENCE file_processing_log_id_seq TO demo_openmrg, demo_orange_cameroun;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - SFTP_USERNAME=demo_orange_cameroun
       - SFTP_REMOTE_PATH=/uploads/douala
       - SFTP_USE_SSH_KEY=true
-      - SFTP_PRIVATE_KEY_PATH=/app/ssh_keys/id_rsa_demo_orange_cameroun
+      - SFTP_PRIVATE_KEY_PATH=/app/ssh_keys/id_rsa_orange_cameroun
       - SFTP_KNOWN_HOSTS_PATH=/app/ssh_keys/known_hosts
       - NETCDF_RSL_VAR=rsl_min
       - NETCDF_TSL_VAR=tsl_min

--- a/grafana/provisioning/datasources/postgres.yml
+++ b/grafana/provisioning/datasources/postgres.yml
@@ -29,23 +29,8 @@ datasources:
     isDefault: true
     editable: false
 
-  # Org 2 — demo_orange_cameroun
-  - name: PostgreSQL
-    uid: ds_demo_orange_cameroun
-    type: grafana-postgresql-datasource
-    access: proxy
-    orgId: 2
-    url: database:5432
-    database: mydatabase
-    user: demo_orange_cameroun
-    secureJsonData:
-      password: demo_orange_cameroun_password
-    jsonData:
-      sslmode: disable
-    isDefault: true
-    editable: false
-
-# Note: provisioning files only apply to Grafana organisations that
-# already exist when Grafana starts.  Org 1 (the default) always
-# exists.  Additional orgs are created by the init_grafana service
-# (grafana/init_grafana.py) before it triggers a provisioning reload.
+# Note: only org 1 is listed above, intentionally.  Grafana reads this
+# file at startup, before init_grafana.py has created orgs 2+.  Listing
+# a non-existent org here causes Grafana to exit with 'org.notFound'.
+# Datasources for additional orgs are registered by init_grafana.py via
+# the Grafana API after those orgs have been created.

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -278,6 +278,11 @@ GRANT SELECT, INSERT, UPDATE ON cml_metadata, cml_stats TO {user_id};
 GRANT SELECT, INSERT, UPDATE ON cml_data_secure TO {user_id};
 GRANT SELECT ON cml_data_1h_secure TO {user_id};
 
+-- file_processing_log: parser INSERTs a row for every processed file;
+-- webserver_role only needs SELECT.
+GRANT SELECT, INSERT ON file_processing_log TO {user_id};
+GRANT USAGE ON SEQUENCE file_processing_log_id_seq TO {user_id};
+
 -- ---------------------------------------------------------------------------
 -- Step 4: Allow webserver_role to impersonate this user
 -- ---------------------------------------------------------------------------

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -370,7 +370,12 @@ def generate_grafana_datasources(users: list[dict]) -> str:
         "  # the correct one — no user interaction required.",
         "",
     ]
-    for u in users:
+    # Only org 1 (the Grafana default org) is provisioned here.  Grafana reads
+    # this file at startup, before init_grafana.py has had a chance to create
+    # orgs 2+.  Provisioning a non-existent org causes Grafana to exit with
+    # "org.notFound".  Additional orgs are created by init_grafana.py and their
+    # datasources are registered there via the Grafana API.
+    for u in users[:1]:
         uid = u["id"]
         org_id = u["grafana_org_id"]
         lines += [
@@ -392,10 +397,11 @@ def generate_grafana_datasources(users: list[dict]) -> str:
             "",
         ]
     lines += [
-        "# Note: provisioning files only apply to Grafana organisations that",
-        "# already exist when Grafana starts.  Org 1 (the default) always",
-        "# exists.  Additional orgs are created by the init_grafana service",
-        "# (grafana/init_grafana.py) before it triggers a provisioning reload.",
+        "# Note: only org 1 is listed above, intentionally.  Grafana reads this",
+        "# file at startup, before init_grafana.py has created orgs 2+.  Listing",
+        "# a non-existent org here causes Grafana to exit with 'org.notFound'.",
+        "# Datasources for additional orgs are registered by init_grafana.py via",
+        "# the Grafana API after those orgs have been created.",
     ]
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## fix: four bugs found during IFU deployment

Four issues discovered during a real deployment with three users. All caused silent failures that required manual inspection to diagnose.

### 1. Grafana crash on startup with ≥2 users
**Files:** `scripts/generate_config.py`, `grafana/provisioning/datasources/postgres.yml`

`generate_grafana_datasources()` emitted a datasource block for every user into `postgres.yml`. Grafana reads this file at startup before `init_grafana.py` has created orgs 2+, causing `org.notFound` and a non-zero exit. Fixed by only emitting the org-1 entry; `init_grafana.py` already handles additional orgs via the API. Updated the trailing comment in the generated file to make the intent explicit.

### 2. Wrong SFTP key path for `mno_simulator_orange_cameroun`
**File:** `docker-compose.yml`

`SFTP_PRIVATE_KEY_PATH` was set to `id_rsa_demo_orange_cameroun` but the committed key file is `id_rsa_orange_cameroun` (no `demo_` prefix). The simulator started without error but silently never uploaded any files.

### 3. `file_processing_log` only grants `SELECT` to user roles; parser needs `INSERT`
**Files:** `database/init.sql`, `database/migrations/008_add_file_processing_log.sql`

The parser connects as the per-user role and calls `log_file_event()` after every file. Both `init.sql` and migration `008` only granted `SELECT`, causing `InsufficientPrivilege` on every insert. This left the Pipeline Health dashboard and `/pipeline-log` page empty. Also corrected the misleading comment in `008` that incorrectly attributed INSERTs to `myuser`.

### 4. Generated user migrations also miss `INSERT` on `file_processing_log`
**File:** `scripts/generate_config.py`

The `_SQL_TEMPLATE` used by `generate_config.py` for new-user migrations had the same omission as `init.sql`/`008`. Fixed so newly generated migrations include `GRANT SELECT, INSERT` and `SEQUENCE USAGE` from the start.