### PR TITLE
fix(generate_config): correct migration template grants

### DIFF
--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -272,11 +272,14 @@ GRANT USAGE ON SCHEMA public TO {user_id};
 -- current_user policy already installed on those tables.
 GRANT SELECT, INSERT, UPDATE ON cml_metadata, cml_stats TO {user_id};
 
--- cml_data has no RLS (compressed TimescaleDB hypertable).  All user access
--- goes through the security-barrier views.  Any direct grant on cml_data —
--- including SELECT — bypasses the WITH CHECK OPTION isolation boundary.
-GRANT SELECT, INSERT, UPDATE ON cml_data_secure TO {user_id};
+-- cml_data has no RLS (compressed TimescaleDB hypertable).
+-- Parser writes (write_rawdata) and stats updates (update_cml_stats) go
+-- directly to cml_data.  Read isolation for webserver/Grafana is provided
+-- by the security-barrier views cml_data_secure / cml_data_1h_secure.
+GRANT SELECT, INSERT, UPDATE ON cml_data TO {user_id};
+GRANT SELECT ON cml_data_secure TO {user_id};
 GRANT SELECT ON cml_data_1h_secure TO {user_id};
+GRANT EXECUTE ON FUNCTION update_cml_stats(TEXT, TEXT) TO {user_id};
 
 -- file_processing_log: parser INSERTs a row for every processed file;
 -- webserver_role only needs SELECT.


### PR DESCRIPTION
generate_config.py emits a DB migration for every new user. The template had two bugs that silently broke any user added via the script:

Bug 1 — wrong table grant: The template granted SELECT, INSERT, UPDATE on the security-barrier view cml_data_secure instead of the underlying hypertable cml_data. Since write_rawdata() and update_cml_stats() both write directly to cml_data, the parser silently dropped all data for the new user.

Bug 2 — missing EXECUTE grant: The template omitted GRANT EXECUTE ON FUNCTION update_cml_stats(TEXT, TEXT). The stats background thread calls this function as the user's PG role, so stats were never computed and map line colouring showed no colour for that user's CMLs.

Also fixes a stale comment that incorrectly stated "all access goes through the security-barrier views."